### PR TITLE
Support Jinja includes

### DIFF
--- a/macros/plugin.py
+++ b/macros/plugin.py
@@ -7,7 +7,7 @@
 # --------------------------------------------
 
 from mkdocs.plugins import BasePlugin
-from jinja2 import Template
+from jinja2 import Environment, FileSystemLoader
 
 from . import module_reader
 
@@ -49,6 +49,11 @@ class MacrosPlugin(BasePlugin):
         module_reader.load_variables(self._variables, config)
 
         print("Variables:", self.variables)
+        
+        env_config = {
+            'loader': FileSystemLoader(config.get('docs_dir'))
+        }
+        self.env = Environment(**env_config)
 
 
     def on_page_markdown(self, markdown, page, config,
@@ -64,8 +69,8 @@ class MacrosPlugin(BasePlugin):
 
         else:
 
-            # Create templae and get the variables
-            md_template = Template(markdown)
+            # Create template and get the variables
+            md_template = self.env.from_string(markdown)
 
             # Execute the jinja2 template and return
             return md_template.render(**self.variables)


### PR DESCRIPTION
This PR addresses issue #7.

It leverages the Jinja `Environment` so set the file loader to the mkdocs `docs_dir` so that includes are resolved relative to that path.

### Example

Directory structure

```
my-docs
  - main.md
  - some-include.md
mkdocs.yml
```

excerpt from `mkdocs.yml`

```yaml
docs_dir: my-docs
```

excerpt from `main.md`

```markdown
{% include "./some-include.md" %}
```

---

Btw, in case somebody needs this and it hasn't been merged yet, you can install `mkdocs_macros_plugin` from my branch with the following statement:

```shell
$ pip install git+https://github.com/mlenkeit/mkdocs_macros_plugin.git@patch-1#egg=mkdocs_macros_plugin
```