### PR TITLE
Add page object to variables

### DIFF
--- a/macros/plugin.py
+++ b/macros/plugin.py
@@ -290,6 +290,7 @@ class MacrosPlugin(BasePlugin):
         if not self.variables:
             return markdown
         else:
+            self._variables["page"] = page
             # Create template and get the variables
             md_template = self.env.from_string(markdown)
             # Execute the jinja2 template and return


### PR DESCRIPTION
This simple change is required for some aditional features. 

In order to creaate some more complex macros and access metadata we need to know in context of which page plugin runs which is possible after this change. 

Example:

```md
---
title: Bla
foo: bar
---

## {{ page.title }}

{{ page.url }}
{{page.meta.foo}}
```

Macros are also able to access page object. I couldn't succeed to make things from issue #6 without this change.