### PR TITLE
Compatible to mkdocs 1.1

### DIFF
--- a/macros/plugin.py
+++ b/macros/plugin.py
@@ -17,8 +17,10 @@ from jinja2 import Environment, FileSystemLoader
 
 from mkdocs.plugins import BasePlugin
 from mkdocs.config.config_options import Type as PluginType
-from mkdocs.utils import string_types
-
+try:
+    from mkdocs.utils import string_types
+except ImportError:
+    string_types = str
 
 from .util import trace, update
 from .context import define_env

--- a/macros/plugin.py
+++ b/macros/plugin.py
@@ -17,6 +17,12 @@ from jinja2 import Environment, FileSystemLoader
 
 from mkdocs.plugins import BasePlugin
 from mkdocs.config.config_options import Type as PluginType
+# -------------------------------------------
+# MkDocs removed string_types in version 1.1.0
+# See issue: https://github.com/mkdocs/mkdocs/issues/1926
+# In order to provide support for MkDocs < 1.1.0 & Python 2.7+
+# This fallback is introduced.
+# -------------------------------------------
 try:
     from mkdocs.utils import string_types
 except ImportError:


### PR DESCRIPTION
mkdocs.utils no longer contains string_types (mkdocs.utils)

This should provide a smooth fallback.
My failed builds: 

```
ImportError: cannot import name 'string_types' from 'mkdocs.utils' (/usr/local/lib/python3.7/site-packages/mkdocs/utils/__init__.py)
```