### PR TITLE
Add **kwargs to on_serve event handler

### DIFF
--- a/macros/plugin.py
+++ b/macros/plugin.py
@@ -383,7 +383,7 @@ class MacrosPlugin(BasePlugin):
         # self.variables['files'] = files
         
         
-    def on_serve(self, server, config):
+    def on_serve(self, server, config, **kwargs):
         """
         Called when the serve command is used during development.
         This is to add files or directories to the list of "watched" 


### PR DESCRIPTION
mkdocs 1.1.1 passes a `builder` kwarg to the `on_serve`
event handler which results in a TypeError if not handled.
This passes it through using **kwargs per the mkdocs best
practice guidance [1].

[1] https://www.mkdocs.org/user-guide/plugins/#on_event_name

Closes #33