### PR TITLE
Require python-dateutil

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,8 @@ setup(
         'jinja2',
         'termcolor',
         'pyyaml',
-        'mkdocs-material'
+        'mkdocs-material',
+        'python-dateutil'
     ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
Commit b8bcfafb59 started using the dateutil package so it should
be listed as a runtime dependency.

Closes #35