### PR TITLE
get_git_info error handling

### DIFF
--- a/macros/context.py
+++ b/macros/context.py
@@ -147,8 +147,15 @@ def get_git_info():
         for var, command in COMMANDS.items():
             # NOTE: The 'text' argument is clearer, 
             #       but for Python < 3.7, only `universal_newlines` is accepted
-            r[var] = subprocess.check_output(command, 
-                                            universal_newlines=True).strip()
+            try:
+                r[var] = subprocess.check_output(command,
+                                                universal_newlines=True).strip()
+            except subprocess.CalledProcessError as e:
+                if var == 'tag' and e.returncode == 128:
+                    # this git repository has no tags
+                    r[var] = str()
+                else:
+                    raise
         # keep first part
         r['tag'] = r['tag'].split('-')[0]
         r['date'] = date_parse(r['date_ISO'])

--- a/macros/context.py
+++ b/macros/context.py
@@ -152,18 +152,19 @@ def get_git_info():
         # keep first part
         r['tag'] = r['tag'].split('-')[0]
         r['date'] = date_parse(r['date_ISO'])
-        # convert 
-        return r
+        # convert
     except subprocess.CalledProcessError as e:
         # no git repository
-        return r.update(
+        r.update(
                 {'diagnosis': 'No git repository',
                 'error': str(e)})
     except FileNotFoundError as e:
         # not git command
-        return r.update(
+        r.update(
                 {'diagnosis': 'Git command not found',
                 'error': str(e)})
+
+    return r
 
 def python_version():
     "Get the python version"


### PR DESCRIPTION
# Diagnosis Information

The except clauses actually return None, because dict().update() returns None.

The pull request changes get_git_info() to actually return the diagnosis information in r. The except clauses now just updates r with `r.update({})` and at the very end of the function, get_git_info() returns r.

# git repositories without tags

If the git repository has no tags, `git describe --tags` fails with error code 128 and aborts git_get_config(). However, the other commands still provide useful information.

This pull request adds a try except block around the git call and ignores error 128 for r['tag']. The function continues to collect information for git repositories without tags.