### PR TITLE
Fix example for including a part of text file

### DIFF
--- a/webdoc/docs/tips.md
+++ b/webdoc/docs/tips.md
@@ -229,7 +229,7 @@ I would like to include a text file, from line a to line b
 
 In the source directory of your MkDocs project
 (where `mkdocs.yml` generally is),
-create a file `module.py`:
+create a file `main.py`:
 
 
 ```{.python}
@@ -256,7 +256,7 @@ def define_env(env):
         with open(full_filename, 'r') as f:
             lines = f.readlines()
         line_range = lines[start_line:end_line]
-        return '\n'.join(line_range)
+        return ''.join(line_range)
 
 ```
 


### PR DESCRIPTION
Fixes example for including selected lines of a file, as provided in https://mkdocs-macros-plugin.readthedocs.io/en/latest/tips/#i-would-like-to-include-a-text-file-from-line-a-to-line-b

The provided example adds a whiteline between all lines of the quoted code:

![import_whitelines](https://user-images.githubusercontent.com/13621049/105347189-d7705100-5be6-11eb-8935-275329d55b2d.png)

This change fixes the rendering of the code block to:

![import_no_whitelines](https://user-images.githubusercontent.com/13621049/105347220-e5be6d00-5be6-11eb-89db-e603a17ba137.png)

Also updates the proposed python file name to one that works out of the box.