### PR TITLE
Fix docu index.md mistake

### DIFF
--- a/webdoc/docs/index.md
+++ b/webdoc/docs/index.md
@@ -89,7 +89,7 @@ their **macros** and **filters**.
     It's actually much, much easier than writing 
     a VBA function for Excel...
 
-    Create a `module.py` file in the top directory of your mkdocs
+    Create a `main.py` file in the top directory of your mkdocs
     project and add this call:
 
         import ...


### PR DESCRIPTION
Hi,  noticed this while reading the docs:
Index page states "Create a `module.py` file in the top directory of your mkdocs", which is wrong and misleading. 
Default module name is `main.py`