### PR TITLE
Don't require mkdocs-material in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,14 +29,13 @@ setup(
     python_requires='>=3.5',
     install_requires=[
         'mkdocs>=0.17',
-        'mkdocs-material>=6.2',
         'jinja2',
         'termcolor',
         'pyyaml',
         'python-dateutil',
     ],
     extras_require={
-        'test': ['mkdocs-macros-test', 'mkdocs-material'],
+        'test': ['mkdocs-macros-test', 'mkdocs-material>=6.2'],
     },
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
After upgrading to v0.5.5, I noticed that the dependency for `mkdocs-material` snuck back into the `install_requires` list. As mentioned in #50, this can cause a non-fatal error when trying to use earlier versions of `mkdocs`:

```
ERROR: mkdocs-material 7.0.6 has requirement mkdocs>=1.1, but you'll have mkdocs 1.0.4 which is incompatible.
```

This patch restores the behavior from the patch in #52, so users installing from PyPI don't automatically install `mkdocs-material` as well.