### PR TITLE
fix: Fallback to variables if macro not found

### DIFF
--- a/mkdocs_macros/plugin.py
+++ b/mkdocs_macros/plugin.py
@@ -178,6 +178,10 @@ class MacrosPlugin(BasePlugin):
 
         name = name or v.__name__
         self.macros[name] = v
+        # Maintain backwards compatible behavior with `variables` for now. In
+        # next major version, we remove this.
+        if name not in self.variables:
+            self.variables[name] = v
         return v
 
 

--- a/test/built-in-macros/docs/index.md
+++ b/test/built-in-macros/docs/index.md
@@ -1,0 +1,4 @@
+{{ macros_info() }}
+{{ button('Try this', 'https://www.google.com') }}
+{{ button2('Try this', 'https://www.google.com') }}
+

--- a/test/built-in-macros/main.py
+++ b/test/built-in-macros/main.py
@@ -1,0 +1,22 @@
+import os
+
+def define_env(env):
+
+    # test predefined macro
+    fix_url = env.variables.fix_url
+    fix_url2 = env.macros.fix_url
+
+    @env.macro
+    def button(label, url):
+        "Add a button"
+        url = fix_url(url)
+        HTML = """<a class='button' href="%s">%s</a>"""
+        return HTML % (url, label)
+
+    @env.macro
+    def button2(label, url):
+        "Add a button"
+        url = fix_url2(url)
+        HTML = """<a class='button' href="%s">%s</a>"""
+        return HTML % (url, label)
+

--- a/test/built-in-macros/mkdocs.yml
+++ b/test/built-in-macros/mkdocs.yml
@@ -1,0 +1,10 @@
+site_name: My own
+theme: mkdocs
+
+nav:
+    - Home: index.md
+
+plugins:
+  - search
+  - macros
+


### PR DESCRIPTION
When defining a macro, also define it in the `variables` property if the
no macro with that name has been defined yet.

This ensures backwards compatible behavior with previous versions that
included built-in macros in the `variables` property.

Issue #87