### PR TITLE
Add setter for raw_markdown to match functionality described in the docs

### DIFF
--- a/mkdocs_macros/plugin.py
+++ b/mkdocs_macros/plugin.py
@@ -231,6 +231,16 @@ class MacrosPlugin(BasePlugin):
             raise AttributeError("Too early: raw markdown is not available"
                                  "at this stage!")
 
+
+    @raw_markdown.setter
+    def raw_markdown(self, value):
+        try:
+            _ = self._raw_markdown
+        except AttributeError:
+            raise AttributeError("Too early: raw markdown is not available"
+                                 "at this stage!")
+        self._raw_markdown = value
+
     # ----------------------------------
     # Function lists, for later events
     # ----------------------------------


### PR DESCRIPTION
Address #98

Adds a setter for the `raw_markdown` property. To prevent misuse, it first checks if the underlying `_raw_markdown` attribute is present similar to the getter.