### PR TITLE
fix broken link in help.md

### DIFF
--- a/webdoc/docs/help.md
+++ b/webdoc/docs/help.md
@@ -3,7 +3,7 @@ Where Can I get Help?
 
 ## RFM 
 
-Read the Frigging on-line [Manual](/index.html) and especially the [Faq](../tips)... seriously: there are good chances that they already contain
+Read the Frigging on-line [Manual](../) and especially the [Faq](../tips)... seriously: there are good chances that they already contain
 the answer you are looking for. 🙂
 
 ## Issues


### PR DESCRIPTION
The link pointing to the manual (aka the main page) does not work as it doesn't include the `/en/latest` path.
Since it's an absolute link did I decide to change it to a relative one (`../`) instead. A quick test showed that it does work.