### PR TITLE
Update Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,23 @@
 # mkdocs-macros-plugin: Unleash the power of MkDocs with variables and macros
 
+# Table of Contents
+* [Overview](#Overview)
+	* [Using variables](#Using-variables)
+	* [Defining variables](#Defining-variables)
+	* [Macros and filters](#Macros-and-filters)
+* [Installation](#Installation)
+	* [Prerequisites](#Prerequisites)
+	* [Standard installation](#Standard-installation)
+	* ["Manual installation"](#"Manual-installation")
+	* [Development/test installation](#Development/test-installation)
+	* [Declaration of plugin](#Declaration-of-plugin)
+	* [Check that it works](#Check-that-it-works)
+* [Using pluglets](#Using-pluglets)
+	* [What are pluglets?](#What-are-pluglets?)
+	* [How to add a pluglet to an mkdocs project?](#How-to-add-a-pluglet-to-an-mkdocs-project?)
+	* [How to write a pluglet?](#How-to-write-a-pluglet?)
+
+
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) 
 ![Language](https://img.shields.io/github/languages/top/fralau/mkdocs_macros_plugin)

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Pluglets are Python packages, which can be hosted on github, and
 distributed through [PyPI](https://pypi.org/).
 
 
-### How to add a pluglet to an mkdocs project?
+### How to add a pluglet to an mkdocs project?
 
 Install it: 
 

--- a/README.md
+++ b/README.md
@@ -1,23 +1,5 @@
 # mkdocs-macros-plugin: Unleash the power of MkDocs with variables and macros
 
-# Table of Contents
-* [Overview](#Overview)
-	* [Using variables](#Using-variables)
-	* [Defining variables](#Defining-variables)
-	* [Macros and filters](#Macros-and-filters)
-* [Installation](#Installation)
-	* [Prerequisites](#Prerequisites)
-	* [Standard installation](#Standard-installation)
-	* ["Manual installation"](#"Manual-installation")
-	* [Development/test installation](#Development/test-installation)
-	* [Declaration of plugin](#Declaration-of-plugin)
-	* [Check that it works](#Check-that-it-works)
-* [Using pluglets](#Using-pluglets)
-	* [What are pluglets?](#What-are-pluglets?)
-	* [How to add a pluglet to an mkdocs project?](#How-to-add-a-pluglet-to-an-mkdocs-project?)
-	* [How to write a pluglet?](#How-to-write-a-pluglet?)
-
-
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) 
 ![Language](https://img.shields.io/github/languages/top/fralau/mkdocs_macros_plugin)
@@ -35,18 +17,21 @@ markdown-toc -i README.md
 <!-- toc -->
 
 - [mkdocs-macros-plugin: Unleash the power of MkDocs with variables and macros](#mkdocs-macros-plugin-unleash-the-power-of-mkdocs-with-variables-and-macros)
-  - [Overview](#overview)
-    - [Using variables](#using-variables)
-    - [Defining variables](#defining-variables)
-    - [Macros and filters](#macros-and-filters)
-  - [Installation](#installation)
-    - [Prerequisites](#prerequisites)
-    - [Standard installation](#standard-installation)
-    - ["Manual installation"](#manual-installation)
-    - [Development/test installation](#developmenttest-installation)
-    - [Declaration of plugin](#declaration-of-plugin)
-    - [Check that it works](#check-that-it-works)
-    - [How to write a pluglet?](#how-to-write-a-pluglet)
+  - [Overview](#Overview)
+    - [Using variables](#Using-variables)
+    - [Defining variables](#Defining-variables)
+    - [Macros and filters](#Macros-and-filters)
+  - [Installation](#Installation)
+    - [Prerequisites](#Prerequisites)
+    - [Standard installation](#Standard-installation)
+    - ["Manual installation"](#"Manual-installation")
+    - [Development/test installation](#Development/test-installation)
+    - [Declaration of plugin](#Declaration-of-plugin)
+    - [Check that it works](#Check-that-it-works)
+  - [Using pluglets](#Using-pluglets)
+    - [What are pluglets?](#What-are-pluglets?)
+    - [How to add a pluglet to an mkdocs project?](#How-to-add-a-pluglet-to-an-mkdocs-project?)
+    - [How to write a pluglet?](#How-to-write-a-pluglet?)
 
 <!-- tocstop -->
 


### PR DESCRIPTION
- [x] Fix `### How to add a pluglet to an mkdocs project?` section.
- [x] Fix TOC.

The following image shows that the `### How to add a pluglet to an mkdocs project?` section of the README does not render correctly due to a strange character (or perhaps another cause). Besides that section is not shown in the TOC.   

![Screenshot_20220103_094209](https://user-images.githubusercontent.com/4896200/147943700-76163d5c-3cba-47f5-835a-0ff9674b4c5d.png)
