### PR TITLE
Leave undefined jinja2 variables as-is

### DIFF
--- a/mkdocs_macros/plugin.py
+++ b/mkdocs_macros/plugin.py
@@ -13,7 +13,7 @@ import importlib
 
 
 import yaml
-from jinja2 import Environment, FileSystemLoader, TemplateSyntaxError
+from jinja2 import Environment, FileSystemLoader, TemplateSyntaxError, DebugUndefined
 from mkdocs.plugins import BasePlugin
 from mkdocs.config import config_options
 from mkdocs.config.config_options import Type as PluginType
@@ -540,8 +540,11 @@ class MacrosPlugin(BasePlugin):
         else:
             debug("Includes directory:", include_dir)
         # will contain all parameters:
+        # undefined jinja2 variables will be left as-is
+            # see https://stackoverflow.com/a/53134416
         env_config = {
-            'loader': FileSystemLoader(include_dir)
+            'loader': FileSystemLoader(include_dir),
+            'undefined': DebugUndefined
         }
         # read the config variables for jinja2:
         for key, value in self.config.items():


### PR DESCRIPTION
The current behaviour of `mkdocs_macros_plugin` is to (silently) replace an unknown jinja2 variable with an empty string.

For example `{{ foobar }}` in a markdown document will be replaced by ""

This PR changes that behaviour and leaves the jinja string (`{{ foobar }}` --> `{{ foobar }}`)

Context is that other plugins might also define custom jinja2 variables. See for example https://github.com/timvink/mkdocs-git-authors-plugin/issues/60 
