### PR TITLE
Add a short_tag attribute to git context

### DIFF
--- a/mkdocs_macros/context.py
+++ b/mkdocs_macros/context.py
@@ -141,6 +141,8 @@ def get_git_info():
         'short_commit': ['git', 'rev-parse', '--short', 'HEAD'],
         'commit': ['git', 'rev-parse', 'HEAD'],
         'tag': ['git', 'describe', '--tags'],
+        # With --abbrev set to 0, git will find the closest tagname without any suffix
+        'short_tag': ['git', 'describe', '--tags', '--abbrev=0'],
         'author': LAST_COMMIT + ["--pretty=format:%an"],
         'author_email': LAST_COMMIT + ["--pretty=format:%ae"],
         'committer': LAST_COMMIT + ["--pretty=format:%cn"],

--- a/webdoc/docs/git_info.md
+++ b/webdoc/docs/git_info.md
@@ -52,7 +52,7 @@ Here is a list of attributes of the git object:
 
 
 | Attribute         | Description                                    |
-| ----------------- | ---------------------------------------------- |
+|-------------------|------------------------------------------------|
 | `short_commit`    | short hash of the last commit (e.g. _2bd7950_) |
 | `commit`          | long hash of the last commit                   |
 | `author`          | author's name                                  |
@@ -60,6 +60,7 @@ Here is a list of attributes of the git object:
 | `committer`       | committer's name                               |
 | `committer_email` | committer's email                              |
 | `tag`             | last active tag of the repo                    |
+| `short_tag`       | last active tag of the repo, abbreviated       |
 | `date`            | full date of the commit (as a date object)     |
 | `date_ISO`        | full date of the commit (as an ISO string)     |
 | `message`         | full message of the last commit                |
@@ -103,6 +104,13 @@ method, e.g.:
 which would return e.g.
 
     May 13, 2020 16:08:52        
+
+## `tag` and `short_tag`
+
+The tag attribute shows the full description of the tag, for
+example `v1.0.4-14-g2414721`. Meanwhile, `short_tag` shows the
+tag name without any suffix, for example `v1.0.4`. The later can
+be usefull when showing the latest release.
 
 ## Tip: Is this really a git repo?
 


### PR DESCRIPTION
## What?

Fixes #184.

This adds a `short_tag`  attribute to the `git` context. It WILL NOT interfere with the changes made to fix #143 since there is no "manual' manipulation of the full tag description, but instead, it uses git itself to get the short name. 

From `git describe --help`:

> The command finds the most recent tag that is reachable from a commit. If the tag points to the commit, then only the tag is shown. Otherwise, **it suffixes the tag name with the number of additional commits on top of the tagged object and the abbreviated object name of the most recent commit**. The result is a "human-readable" object name which can also be used to identify the commit to other git commands.

And later, when describing `--abbrev=0`:

> With --abbrev set to 0, the command can be used to find the closest tagname without any suffix:
>
>     [torvalds@g5 git]$ git describe --abbrev=0 v1.0.5^2
>     tags/v1.0.0

## Why?

This is useful when showing latest release info, for example.

