### PR TITLE
Fixed:doc:changelog

### DIFF
--- a/webdoc/docs/changelog.md
+++ b/webdoc/docs/changelog.md
@@ -1,4 +1,1 @@
-
-{% 
-    include-markdown "../../CHANGELOG.md" 
-%}
+--8<-- "https://raw.githubusercontent.com/fralau/mkdocs_macros_plugin/master/CHANGELOG.md"

--- a/webdoc/mkdocs.yml
+++ b/webdoc/mkdocs.yml
@@ -46,6 +46,8 @@ markdown_extensions:
         - name: mermaid
           class: mermaid
           format: !!python/name:mermaid2.fence_mermaid_custom
+  - pymdownx.snippets:
+      url_download: true
 
 plugins:
   # do not use the macros plugin, for 


### PR DESCRIPTION
After remove the include-markdown plugin, the `changelog.md` is broken, we can use `pymdownx.snippets` to fix it. #186.