### PR TITLE
Add `branch` as information available through git

### DIFF
--- a/mkdocs_macros/context.py
+++ b/mkdocs_macros/context.py
@@ -141,6 +141,7 @@ def get_git_info():
         'short_commit': ['git', 'rev-parse', '--short', 'HEAD'],
         'commit': ['git', 'rev-parse', 'HEAD'],
         'tag': ['git', 'describe', '--tags'],
+        'branch': ['git', 'rev-parse', '--abbrev-ref', 'HEAD'],
         # With --abbrev set to 0, git will find the closest tagname without any suffix
         'short_tag': ['git', 'describe', '--tags', '--abbrev=0'],
         'author': LAST_COMMIT + ["--pretty=format:%an"],


### PR DESCRIPTION
I am using `mkdocs-macro` plugin to configure the `mike` plugin for `mkdocs` in order to display multi-version documentation. In that context, I would like to mark certain branches as `dev` and others as `experimental`. And for that,  I need the branch names in `git` as well. 

I've added the `branch` property in `get_git_info()`.