### PR TITLE
Enable j2 extensions in mkdocs-macros without false-positive warning

### DIFF
--- a/mkdocs_macros/plugin.py
+++ b/mkdocs_macros/plugin.py
@@ -116,6 +116,7 @@ class MacrosPlugin(BasePlugin):
     """
 
     # what is under the 'macros' namespace (will go into the config property):
+    J2_STRING = PluginType(str, default='')
     J2_STRING_LIST = ListOfItems(J2_STRING, default=[])
     config_scheme = (
         # main python module:


### PR DESCRIPTION
Fixes #272 

- Handle List of String config option type
    - Import `mkdocs.config.config_options.ListOfTypes`.
    - Add J2_STRING_LIST config option.
- Resolve cause of warning
    - Add j2_extensions to config scheme using new J2_STRING_LIST type.