### PR TITLE
fix: add `j2_line_statement_prefix` and `j2_line_comment_prefix` to plugin config scheme

### DIFF
--- a/mkdocs_macros/plugin.py
+++ b/mkdocs_macros/plugin.py
@@ -144,6 +144,8 @@ class MacrosPlugin(BasePlugin):
         ('j2_variable_end_string',   J2_STRING),
         ('j2_comment_start_string',  J2_STRING),
         ('j2_comment_end_string',    J2_STRING),
+        ('j2_line_statement_prefix', J2_STRING),
+        ('j2_line_comment_prefix', J2_STRING),
         # for including j2 extensions:
         # https://jinja.palletsprojects.com/en/stable/extensions/
         ('j2_extensions', J2_STRING_LIST),


### PR DESCRIPTION
Fix: https://github.com/fralau/mkdocs-macros-plugin/issues/288
- Add below scheme entries in `config_scheme`:
```python
('j2_line_statement_prefix', J2_STRING),
('j2_line_comment_prefix', J2_STRING),
```

These are valid Jinja `Environment` options for enabling line statements and line comments.

`mkdocs-macros-plugin` already forwards `j2_*` config options to Jinja by stripping the `j2_` prefix, so `j2_line_comment_prefix` and `j2_line_statement_prefix` works at runtime today. However, because it is not declared in `config_scheme`, MkDocs reports it as an unrecognized option.

